### PR TITLE
Deep copy cells so they dont inherit everything from their parents

### DIFF
--- a/CellModeller/Simulator.py
+++ b/CellModeller/Simulator.py
@@ -144,8 +144,8 @@ visualised.
         pid = pState.id
         d1id = self.next_id()
         d2id = self.next_id()
-        d1State = copy.copy(pState)
-        d2State = copy.copy(pState)
+        d1State = copy.deepcopy(pState)
+        d2State = copy.deepcopy(pState)
         d1State.id = d1id
         d2State.id = d2id
 


### PR DESCRIPTION
There was a bug where if you changed the value of a species in a cell, it was set also in all descendents of that cell.
