### PR TITLE
Add a dictionary linking idxs to ids 

### DIFF
--- a/CellModeller/Simulator.py
+++ b/CellModeller/Simulator.py
@@ -28,6 +28,7 @@ visualised.
         self._next_id = 1
         self._next_idx = 0
         self.idToIdx = {}
+        self.idxToId = {}
         # Map from id to cell state
         self.cellStates = {}
         self.reg = None
@@ -160,8 +161,10 @@ visualised.
         # Update indexing, reuse parent index for d1
         d1State.idx = pState.idx
         self.idToIdx[d1id] = pState.idx
+        self.idxToId[pState.idx] = d1id
         d2State.idx = self.next_idx()
         self.idToIdx[d2id] = d2State.idx
+        self.idxToId[d2State.idx] = d2id
         del self.idToIdx[pid]
 
         # Divide the cell in each model
@@ -178,6 +181,7 @@ visualised.
         cs.idx = self.next_idx()
         cs.cellType = cellType
         self.idToIdx[cid] = cs.idx
+        self.idxToId[cs.idx] = cid
         self.cellStates[cid] = cs
         if self.integ:
             self.integ.addCell(cs)
@@ -185,6 +189,7 @@ visualised.
         if self.sig:
             self.sig.addCell(cs)
         self.phys.addCell(cs, **kwargs)
+        return cid, cs
 
 
     def step(self):


### PR DESCRIPTION
There is currently a dictionary from ids to idxs, this is not very useful since if we have the id we can get the cell from the cellstate dictionary and then get its idx. 
However frequently I need to go the other way, I have the idx and I want to get the id. 

I might be an idea to remove id_to_idx altogether. 
