### PR TITLE
make it easier to run from different dirs. make it so we can use printf ...

### DIFF
--- a/CellModeller/Biophysics/BacterialModels/CLBacterium.py
+++ b/CellModeller/Biophysics/BacterialModels/CLBacterium.py
@@ -1,6 +1,7 @@
 import sys
 import math
 import numpy
+import os.path
 import pyopencl as cl
 import pyopencl.array as cl_array
 from pyopencl.array import vec
@@ -115,7 +116,8 @@ class CLBacterium:
 
     def init_kernels(self):
         """Set up the OpenCL kernels."""
-        kernel_src = open('CellModeller/Biophysics/BacterialModels/CLBacterium.cl', 'r').read()
+        dir_this_file_is_in = os.path.dirname(os.path.realpath(__file__))
+        kernel_src = open(os.path.join(dir_this_file_is_in, 'CLBacterium.cl'), 'r').read()
         self.program = cl.Program(self.context, kernel_src).build(cache_dir=False)
 
         # Some kernels that seem like they should be built into pyopencl...

--- a/CellModeller/Integration/CLCrankNicIntegrator.cl
+++ b/CellModeller/Integration/CLCrankNicIntegrator.cl
@@ -2,11 +2,11 @@
 
 void userSignalRates(float gridVolume, float area, float volume, const int cellType, float* rates, __global const float* species, __global const float* signals)
 {
-    %s
+    $sigRate
 }
 void userSpecRates(float gridVolume, float area, float volume, const int cellType, __global float* rates, __global const float* species, __global const float* signals)
 {
-    %s
+    $specRate
 }
 
 __kernel void gridCells(const float gridOrigx,
@@ -149,7 +149,7 @@ __kernel void signalRates(const int numSignals,
     __global const float* species = cellSpecLevels+specbase;
     __global const float* signals = cellSignalLevels+sigbase;
 
-    float cellSigRates[%i];
+    float cellSigRates[$num_signals];
     userSignalRates(gridVolume, areas[id], volumes[id], cellType, cellSigRates, species, signals);
 
     // Iterate over 8 nearest grid nodes

--- a/CellModeller/Integration/CLCrankNicIntegrator.py
+++ b/CellModeller/Integration/CLCrankNicIntegrator.py
@@ -4,6 +4,7 @@ from scipy.sparse.linalg import LinearOperator
 from scipy.ndimage.filters import convolve
 from scipy.sparse.linalg import gmres
 import os.path
+from string import Template
 import pyopencl as cl
 import pyopencl.array as cl_array
 from pyopencl.array import vec

--- a/CellModeller/Integration/CLCrankNicIntegrator.py
+++ b/CellModeller/Integration/CLCrankNicIntegrator.py
@@ -3,6 +3,7 @@ import scipy.integrate.odepack
 from scipy.sparse.linalg import LinearOperator
 from scipy.ndimage.filters import convolve
 from scipy.sparse.linalg import gmres
+import os.path
 import pyopencl as cl
 import pyopencl.array as cl_array
 from pyopencl.array import vec
@@ -201,9 +202,11 @@ class CLCrankNicIntegrator:
         # Get user defined kernel source
         specRateKernel = self.regul.specRateCL()
         sigRateKernel = self.regul.sigRateCL()
-        kernel_src = open('CellModeller/Integration/CLCrankNicIntegrator.cl', 'r').read()
-        # substitute user defined kernel code, and number of signals
-        kernel_src = kernel_src%(sigRateKernel, specRateKernel, self.nSignals)
+        dir_this_file_is_in = os.path.dirname(os.path.realpath(__file__))
+        kernel_src = Template(open(os.path.join(dir_this_file_is_in, 'CLCrankNicIntegrator.cl'), 'r').read())
+        kernel_src = kernel_src.substitute(sigRate = sigRateKernel,
+                    specRate=specRateKernel,
+                    num_signals=self.nSignals)
         self.program = cl.Program(self.context, kernel_src).build(cache_dir=False)
 
 


### PR DESCRIPTION
When running CellModeller from an arbitrary location in the file system we need a different way to find the opencl code. This commit assumes that the opencl code is in the same dir as the python code. 

Also if we want to use printf in opencl the %'s in the integrator make it difficult.
I changed the way to add in the reactions so it doesnt use %'s. 
