### PR TITLE
replace use of deprecated imp for importlib.utils

### DIFF
--- a/CellModeller/Regulation/ModuleRegulator.py
+++ b/CellModeller/Regulation/ModuleRegulator.py
@@ -1,7 +1,6 @@
 import copy
 import os.path
 import sys
-import imp
 
 class ModuleRegulator:
     def __init__(self, sim, biophys=None, signalling=None):

--- a/CellModeller/Simulator.py
+++ b/CellModeller/Simulator.py
@@ -7,7 +7,6 @@ import pickle
 import csv
 import numpy
 import inspect
-import imp
 import configparser
 import importlib
 
@@ -77,7 +76,8 @@ visualised.
         self.moduleStr = moduleStr # Import stored python code string (from a pickle usually)
         if self.moduleStr:
             print("Importing model %s from string"%(self.moduleName))
-            self.module = imp.new_module(moduleName)
+            module_spec = importlib.util.spec_from_loader(moduleName, loader=None)
+            self.module = importlib.util.module_from_spec(module_spec)
             exec(moduleStr, self.module.__dict__)
         else:
             # In case the moduleName is a path to a python file:


### PR DESCRIPTION
The imp library was deprecated in Python 3.4 and has been finally removed of the standard library in version 3.12.
Instead, importlib needs to be used -- otherwise people with the new version of Python won't be able to run the code.

I have also removed the imp library from `ModuleRegulator` as it was not being used anyway.